### PR TITLE
Expose outputDir folder for the node test plugins

### DIFF
--- a/src/main/kotlin/com/github/salomonbrys/gradle/kotlin/js/jstests/node/KotlinJsTestsNodePlugin.kt
+++ b/src/main/kotlin/com/github/salomonbrys/gradle/kotlin/js/jstests/node/KotlinJsTestsNodePlugin.kt
@@ -52,7 +52,7 @@ abstract class KotlinJsTestsNodePlugin<E: KotlinJsTestsNodeExtension> : KtPlugin
 
         target.testCompileTask.kotlinOptions.moduleKind = "commonjs"
 
-        val testDir = "${project.buildDir}/test-js/${target.name}"
+        val testDir = target.outputDir
 
         val copyModules = project.task<Copy>("${target.name}TestCopyModules") {
             group = "build"

--- a/src/main/kotlin/com/github/salomonbrys/gradle/kotlin/js/jstests/node/KotlinJsTestsNodeTarget.kt
+++ b/src/main/kotlin/com/github/salomonbrys/gradle/kotlin/js/jstests/node/KotlinJsTestsNodeTarget.kt
@@ -9,4 +9,6 @@ open class KotlinJsTestsNodeTarget(private val name: String, val mainCompileTask
 
     var engine: Engine = Engine.default
 
+    var outputDir: String = "${testCompileTask.project.buildDir}/test-js/$name"
+
 }


### PR DESCRIPTION
Hello,
First of all, thanks for those plugins; really easier and faster to setup KotlinJs project with those!
A small PR to expose in the js-tests.node plugin API the folder used to run the JS tests. Can be useful to configure other engines or for example to specify path for test report files.